### PR TITLE
Fix action input ref call

### DIFF
--- a/src/components/action-input/ActionInput.jsx
+++ b/src/components/action-input/ActionInput.jsx
@@ -44,7 +44,7 @@ class ActionInput extends Component {
   }
 
   focus() {
-    findDOMNode(this.actionInputControl.current).focus();
+    findDOMNode(this.actionInputControlRef.current).focus();
   }
 
   updateComponentsFromProps(children) {


### PR DESCRIPTION
Ref name is `actionInputControlRef` & we were calling `actionInputControl`