### PR TITLE
Add support for checking file type before uploading

### DIFF
--- a/src/components/image-preview/style.scss
+++ b/src/components/image-preview/style.scss
@@ -78,8 +78,6 @@
     line-height: 48px;
     color: #ffffff;
     z-index: 999999;
-    height: inherit;
-    width: inherit;
     top: 0;
     right: 0;
   }

--- a/src/components/image-uploader/ImageUploader.jsx
+++ b/src/components/image-uploader/ImageUploader.jsx
@@ -27,7 +27,9 @@ const ACCEPT_TYPES = {
   PNG: 'image/png',
 };
 
-const shouldCheckImageType = type !== ACCEPT_TYPES.ANY;
+function shouldCheckImageType(type) {
+  return type !== ACCEPT_TYPES.ANY;
+} 
 
 export default class ImageUploader extends React.Component {
   constructor(props) {
@@ -164,7 +166,7 @@ export default class ImageUploader extends React.Component {
   
       const currentFile = files[0];
   
-      if (shouldCheckImageType && currentFile.type !== acceptType) {
+      if (shouldCheckImageType(acceptType) && currentFile.type !== acceptType) {
         return this.handleUploadFailed(imageUploadInvalidType());
       }
   

--- a/src/components/image-uploader/ImageUploader.jsx
+++ b/src/components/image-uploader/ImageUploader.jsx
@@ -27,6 +27,8 @@ const ACCEPT_TYPES = {
   PNG: 'image/png',
 };
 
+const shouldCheckImageType = type !== ACCEPT_TYPES.ANY;
+
 export default class ImageUploader extends React.Component {
   constructor(props) {
     super(props);
@@ -155,14 +157,14 @@ export default class ImageUploader extends React.Component {
   }
 
   handleDrop(files) {
-    const { acceptType, checkImageType } = this.props;
+    const { acceptType } = this.props;
   
     if (files && files.length > 0) {
       this.setState({ uploading: true, error: null });
   
       const currentFile = files[0];
   
-      if (checkImageType && currentFile.type !== acceptType) {
+      if (shouldCheckImageType && currentFile.type !== acceptType) {
         return this.handleUploadFailed(imageUploadInvalidType());
       }
   
@@ -253,10 +255,6 @@ ImageUploader.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Flag indicating whether image type should be checked before uploading
-   */
-  checkImageType: PropTypes.bool,
-  /**
    * Expected image height in pixels
    */
   height: PropTypes.number,
@@ -328,7 +326,6 @@ ImageUploader.defaultProps = {
   acceptType: ACCEPT_TYPES.ANY,
   autoResize: true,
   canBeDeleted: true,
-  checkImageType: false,
   icon: 'add',
   maxImageSize: 10000000,
   previewSize: 'small',

--- a/src/components/image-uploader/ImageUploader.jsx
+++ b/src/components/image-uploader/ImageUploader.jsx
@@ -7,7 +7,11 @@ import Dropzone from 'react-dropzone';
 import classNames from 'classnames';
 import { LoaderContainer } from '../loader';
 import ImagePreview from '../image-preview';
-import { imageSizeTooBigError, imageUploadError } from './errors';
+import {
+  imageSizeTooBigError,
+  imageUploadError,
+  imageUploadInvalidType,
+} from './errors';
 import {
   resizeImage as resizeImageService,
   calculateValidImageDimensions,
@@ -15,6 +19,13 @@ import {
   shouldResizeImage,
 } from './image';
 import './style.scss';
+
+const ACCEPT_TYPES = {
+  ANY: 'image/*',
+  JPG: 'image/jpg',
+  JPEG: 'image/jpeg',
+  PNG: 'image/png',
+};
 
 export default class ImageUploader extends React.Component {
   constructor(props) {
@@ -144,10 +155,18 @@ export default class ImageUploader extends React.Component {
   }
 
   handleDrop(files) {
+    const { acceptType, checkImageType } = this.props;
+  
     if (files && files.length > 0) {
       this.setState({ uploading: true, error: null });
-
-      this.upload(files[0]).then(
+  
+      const currentFile = files[0];
+  
+      if (checkImageType && currentFile.type !== acceptType) {
+        return this.handleUploadFailed(imageUploadInvalidType());
+      }
+  
+      this.upload(currentFile).then(
         this.handleUploadSucceeded,
         this.handleUploadFailed,
       );
@@ -202,54 +221,90 @@ export default class ImageUploader extends React.Component {
 
 ImageUploader.propTypes = {
   /**
+   * Object containing methods for uploading, listing, and deleting files on cloud
+   */
+   assetManager: PropTypes.shape({
+    deleteFile: PropTypes.func.isRequired,
+    uploadFile: PropTypes.func.isRequired,
+    listFolder: PropTypes.func.isRequired,
+  }).isRequired,
+  /**
+   * Path where to upload file
+   */
+  folderName: PropTypes.string.isRequired,
+  /**
    *  Callback invoked when image is uploaded
    */
   onUploadSuccess: PropTypes.func.isRequired,
   /**
-   *  Callback invoked when upload fails
+   * Accepted image type, used when checking image type
    */
-  onError: PropTypes.func,
+  acceptType: PropTypes.string,
+  /**
+   * Flag indicating whether image should automatically be resized if it's not in correct dimensions
+   */
+  autoResize: PropTypes.bool,
+  /**
+   * Flag indicating whether image can be deleted
+   */
+  canBeDeleted: PropTypes.bool,
   /**
    * Additional classes to apply
    */
   className: PropTypes.string,
   /**
-   *  Id of the image
+   * Flag indicating whether image type should be checked before uploading
    */
-  id: PropTypes.string,
+  checkImageType: PropTypes.bool,
   /**
-   *  Url to the preview image
+   * Expected image height in pixels
    */
-  preview: PropTypes.string,
+  height: PropTypes.number,
   /**
-   * Min allowed image width in pixels
+   * Help text positioned below dropzone
    */
-  minWidth: PropTypes.number,
-  /**
-   * Min allowed image height in pixels
-   */
-  minHeight: PropTypes.number,
-  /**
-   * Max allowed image width in pixels
-   */
-  maxWidth: PropTypes.number,
-  /**
-   * Max allowed image height in pixels
-   */
-  maxHeight: PropTypes.number,
-  /**
-   * Max allowed image size in bytes
-   */
-  maxImageSize: PropTypes.number,
+  helpText: PropTypes.string,
   /**
    * FontIcon name (add-photo, add...)
    */
   icon: PropTypes.string,
   /**
+   *  Id of the image
+   */
+  id: PropTypes.string,
+  /**
+   * Min allowed image height in pixels
+   */
+  minHeight: PropTypes.number,
+  /**
+   * Min allowed image width in pixels
+   */
+  minWidth: PropTypes.number,
+  /**
+   * Max allowed image size in bytes
+   */
+  maxImageSize: PropTypes.number,
+  /**
+   * Max allowed image height in pixels
+   */
+  maxHeight: PropTypes.number,
+  /**
+   * Max allowed image width in pixels
+   */
+  maxWidth: PropTypes.number,
+  /**
+   * Url to the preview image
+   */
+  preview: PropTypes.string,
+  /**
    * Passed on as a prop to the ImagePreview component,
    * determines image preview block dimensions
    */
   previewSize: PropTypes.string,
+  /**
+   * Customize your file name before the upload
+   */
+  resolveFilename: PropTypes.func,
   /**
    * Flag indicating whether to show validation error in component.
    * If set to false, onError function should be provided for displaying upload error.
@@ -260,50 +315,24 @@ ImageUploader.propTypes = {
    */
   width: PropTypes.number,
   /**
-   * Expected image height in pixels
+   * Callback invoked when upload fails
    */
-  height: PropTypes.number,
-  /**
-   * Help text positioned below dropzone
-   */
-  helpText: PropTypes.string,
-  /**
-   * Object containing methods for uploading, listing, and deleting files on cloud
-   */
-  assetManager: PropTypes.shape({
-    deleteFile: PropTypes.func.isRequired,
-    uploadFile: PropTypes.func.isRequired,
-    listFolder: PropTypes.func.isRequired,
-  }),
-  /**
-   * Path where to upload file
-   */
-  folderName: PropTypes.string,
-  /**
-   * Customize your file name before the upload
-   */
-  resolveFilename: PropTypes.func,
+  onError: PropTypes.func,
   /**
    *  Callback forwarded to ImagePreview component; invoked when existing image is deleted
    */
   onDeleteSuccess: PropTypes.func,
-  /**
-   * Flag indicating whether image can be deleted
-   */
-  canBeDeleted: PropTypes.bool,
-  /**
-   * Flag indicating whether image should automatically be resized if it's not in correct dimensions
-   */
-  autoResize: PropTypes.bool,
 };
 
 ImageUploader.defaultProps = {
-  maxImageSize: 10000000,
-  onError: () => {},
-  icon: 'add',
-  previewSize: 'small',
-  showValidationError: true,
-  canBeDeleted: true,
+  acceptType: ACCEPT_TYPES.ANY,
   autoResize: true,
+  canBeDeleted: true,
+  checkImageType: false,
+  icon: 'add',
+  maxImageSize: 10000000,
+  previewSize: 'small',
   resolveFilename: file => file.name,
+  showValidationError: true,
+  onError: () => {}, 
 };

--- a/src/components/image-uploader/const.js
+++ b/src/components/image-uploader/const.js
@@ -23,6 +23,8 @@ export const IMAGE_UPLOAD_HEIGHT_INVALID =
 export const IMAGE_UPLOAD_SIZE_TOO_BIG =
   'shoutem.builder.image-uploader.size-small';
 export const IMAGE_UPLOAD_ERROR = 'shoutem.builder.image-uploader.upload-fail';
+export const IMAGE_UPLOAD_INVALID_TYPE =
+  'shoutem.builder.image-uploader.invalid-type';
 
 export const IMAGE_PREVIEW_DELETE_ERROR =
   'shoutem.builder.image-preview.delete-error';

--- a/src/components/image-uploader/errors.js
+++ b/src/components/image-uploader/errors.js
@@ -61,6 +61,10 @@ export function imageUploadError() {
   return getMessage(IMAGE_UPLOAD_ERROR);
 }
 
+export function imageUploadInvalidType() {
+  return getMessage(IMAGE_UPLOAD_INVALID_TYPE);
+}
+
 export function imagePreviewDeleteError() {
   return getMessage(IMAGE_PREVIEW_DELETE_ERROR);
 }

--- a/src/components/image-uploader/localization/dictionary.js
+++ b/src/components/image-uploader/localization/dictionary.js
@@ -11,6 +11,7 @@ import {
   IMAGE_UPLOAD_HEIGHT_INVALID,
   IMAGE_UPLOAD_SIZE_TOO_BIG,
   IMAGE_UPLOAD_ERROR,
+  IMAGE_UPLOAD_INVALID_TYPE,
   IMAGE_PREVIEW_DELETE_ERROR,
 } from '../const';
 
@@ -37,5 +38,6 @@ export default {
     `Image width must be exactly ${width}px!`,
   [IMAGE_UPLOAD_HEIGHT_INVALID]: ({ height }) =>
     `Image height must be exactly ${height}px!`,
+  [IMAGE_UPLOAD_INVALID_TYPE]: 'File type is invalid.',
   [IMAGE_PREVIEW_DELETE_ERROR]: 'Delete failed.',
 };


### PR DESCRIPTION
Added `checkImageType` & `acceptType` props to validate image file before it's uploaded.

Sorted prop types as much as I could manually, since eslint doesn't seem to work properly.